### PR TITLE
Cut the README down to the retirement notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,69 +15,20 @@
  limitations under the License.
 -->
 Contributing to [Apache Maven Stage Plugin](https://maven.apache.org/plugins/maven-stage-plugin/)
-======================
+RETIRED - [Apache Maven Stage Plugin](https://maven.apache.org/plugins/maven-stage-plugin/)
+===========================================================================================
 
 [![Apache License, Version 2.0, January 2004](https://img.shields.io/github/license/apache/maven.svg?label=License)][license]
 [![Maven Central](https://img.shields.io/maven-central/v/org.apache.maven.plugins/maven-stage-plugin.svg?label=Maven%20Central)](https://search.maven.org/artifact/org.apache.maven.plugins/maven-stage-plugin)
-[![Jenkins Status](https://img.shields.io/jenkins/s/https/ci-maven.apache.org/job/Maven/job/maven-box/job/maven-stage-plugin/job/master.svg?)][build]
-[![Jenkins tests](https://img.shields.io/jenkins/t/https/ci-maven.apache.org/job/Maven/job/maven-box/job/maven-stage-plugin/job/master.svg?)][test-results]
 
+This plugin is retired. It is no longer maintained.
+---------------------------------------------------
 
-You have found a bug, or you have an idea for a cool new feature? Contributing
-code is a great way to give something back to the open source community. Before
-you dig right into the code, there are a few guidelines that we need
-contributors to follow so that we can have a chance of keeping on top of
-things.
+The Apache Maven project voted to retire it on 2025-11-29. No further releases
+will be made and the repository no longer accepts contributions. The last released
+version is 1.0, which remains available from Maven Central.
 
-Getting Started
----------------
-
-+ Make sure you have a [GitHub account](https://github.com/signup/free).
-+ If you're planning to implement a new feature, it makes sense to discuss your changes 
-  on the [dev list][ml-list] first. 
-  This way you can make sure you're not wasting your time on something that isn't 
-  considered to be in Apache Maven's scope.
-+ Submit a ticket for your issue, assuming one does not already exist.
-  + Clearly describe the issue, including steps to reproduce when it is a bug.
-  + Make sure you fill in the earliest version that you know has the issue.
-+ Fork the repository on GitHub.
-
-Making and Submitting Changes
---------------
-
-We accept Pull Requests via GitHub. The [developer mailing list][ml-list] is the
-main channel of communication for contributors.  
-There are some guidelines which will make applying PRs easier for us:
-+ Create a topic branch from where you want to base your work (this is usually the master branch).
-  Push your changes to a topic branch in your fork of the repository.
-+ Make commits of logical units.
-+ Respect the original code style: by using the same [codestyle][code-style],
-  patches should only highlight the actual difference, not being disturbed by any formatting issues:
-  + Only use spaces for indentation.
-  + Create minimal diffs - disable on save actions like reformat source code or organize imports. 
-    If you feel the source code should be reformatted, create a separate PR for this change.
-  + Check for unnecessary whitespace with `git diff --check` before committing.
-+ Make sure you have added the necessary tests (JUnit/IT) for your changes.
-+ Run all the tests with `mvn -Prun-its verify` to assure nothing else was accidentally broken.
-+ Submit a pull request to the repository in the Apache organization.
-
-If you plan to contribute on a regular basis, please consider filing a [contributor license agreement][cla].
-
-Additional Resources
---------------------
-
-+ [Contributing patches](https://maven.apache.org/guides/development/guide-maven-development.html#Creating_and_submitting_a_patch)
-+ [Contributor License Agreement][cla]
-+ [General GitHub documentation](https://help.github.com/)
-+ [GitHub pull request documentation](https://help.github.com/send-pull-requests/)
-+ [Apache Maven X Account](https://x.com/ASFMavenProject)
-+ [Apache Maven Bluesky Account](https://bsky.app/profile/maven.apache.org)
-+ [Apache Maven Mastodon Account](https://mastodon.social/deck/@ASFMavenProject@fosstodon.org)
+If you have questions, please [contact the Apache Maven development team][ml-list].
 
 [license]: https://www.apache.org/licenses/LICENSE-2.0
 [ml-list]: https://maven.apache.org/mailing-lists.html
-[code-style]: https://maven.apache.org/developers/conventions/code.html
-[cla]: https://www.apache.org/licenses/#clas
-[maven-wiki]: https://cwiki.apache.org/confluence/display/MAVEN/Index
-[test-results]: https://ci-maven.apache.org/job/Maven/job/maven-box/job/maven-stage-plugin/job/master/lastCompletedBuild/testReport/
-[build]: https://ci-maven.apache.org/job/Maven/job/maven-box/job/maven-stage-plugin/job/master/


### PR DESCRIPTION
Trims the README to what is still true now that the plugin is retired.

The file was the standard "Contributing to ..." guide — fork the repo, open a pull request, run the ITs with `mvn -Prun-its verify`, file a ticket. None of that is actionable on a retired plugin whose repository is about to be archived read only, and leaving it there invites work nobody can accept.

What remains: that it is retired, when the project voted, the last released version, and where to ask a question. Deliberately no links to the vote thread, the INFRA ticket or the cleanup PRs — a reader who lands here wants to know whether to use the plugin, not to follow the paperwork. Questions go to the [Maven mailing lists](https://maven.apache.org/mailing-lists.html) page.

Also drops the two Jenkins badges: deleting the `Jenkinsfile` removed the `maven-box` job they pointed at, so they can only ever render broken now. The license and Maven Central badges still resolve and stay.

Modelled on the README `maven-pdf-plugin` was left with when it was retired.

**This wants to merge before INFRA acts on INFRA-28233** — once the repository is archived it is read only and the README is frozen as it stands.

<sub>Drafted with Claude — please verify</sub>