### PR TITLE
Fix the README header and unlink it from the plugin site

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -->
-Contributing to [Apache Maven Stage Plugin](https://maven.apache.org/plugins/maven-stage-plugin/)
 RETIRED - [Apache Maven Stage Plugin](https://maven.apache.org/plugins/maven-stage-plugin/)
 ===========================================================================================
 

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -->
-RETIRED - [Apache Maven Stage Plugin](https://maven.apache.org/plugins/maven-stage-plugin/)
-===========================================================================================
+RETIRED - Apache Maven Stage Plugin
+===================================
 
 [![Apache License, Version 2.0, January 2004](https://img.shields.io/github/license/apache/maven.svg?label=License)][license]
 [![Maven Central](https://img.shields.io/maven-central/v/org.apache.maven.plugins/maven-stage-plugin.svg?label=Maven%20Central)](https://search.maven.org/artifact/org.apache.maven.plugins/maven-stage-plugin)


### PR DESCRIPTION
Two README fixes for the retirement notice.

1. **Removes the leftover title line.** The commit that trimmed the README left the old `Contributing to ...` line above the new title, so the header rendered as two run-together headings.
2. **Unlinks the title from the plugin site.** That site goes to the archive along with the plugin, so a link there would rot inside a README nobody can edit once the repository is read only. The plugin name alone identifies it, and the mailing-list link further down still resolves — that page outlives any individual component.

Result:

```
RETIRED - Apache Maven Stage Plugin
===================================
```

Wants to merge before INFRA acts on INFRA-28233.

<sub>Drafted with Claude — please verify</sub>