### PR TITLE
Point the .asf.yaml homepage at the Maven site and drop the Jira autolink

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -17,6 +17,7 @@
 # see https://s.apache.org/asfyaml
 github:
   description: "Apache Maven Stage Plugin (RETIRED)"
+  homepage: https://maven.apache.org/
   labels:
     - java
     - build-management

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -17,7 +17,6 @@
 # see https://s.apache.org/asfyaml
 github:
   description: "Apache Maven Stage Plugin (RETIRED)"
-  homepage: https://maven.apache.org/plugins/maven-stage-plugin/
   labels:
     - java
     - build-management
@@ -32,8 +31,6 @@ github:
     squash: true
     merge: false
     rebase: true
-  autolink_jira:
-    - MSTAGE
   features:
     issues: true
 notifications:


### PR DESCRIPTION
Two `github:` entries that describe a plugin still under development.

| Key | Change | Why |
|---|---|---|
| `homepage` | now `https://maven.apache.org/` | The plugin site goes to the archive with the plugin, so the "About" link would eventually resolve to nothing. |
| `autolink_jira` | removed | Turns ticket references into links to a Jira project that INFRA-28233 asks to archive alongside this repository. |

Worth knowing which of these actually takes effect, from `infrastructure-asfyaml`:

- `feature/github/metadata.py` — `if homepage and not self.noop("homepage")`. Any truthy value is applied, so **setting** the homepage overwrites what GitHub stores. An absent key or empty string is skipped, so *removing* it could never clear the old URL — which is why this sets rather than deletes.
- `feature/github/autolink.py` — only ever calls `create_autolink`. There is no deletion path, so the existing `MSTAGE-` autolink survives this change; clearing it needs INFRA and has been raised there.

`features.issues` stays enabled deliberately. `feature/github/features.py` passes `has_issues=features.get("issues", False)`, so dropping the key while keeping the `features` block would actively disable issues and hide all 29 issue records, including everything migrated out of Jira. An archived repository keeps its issues readable; one with the feature disabled does not.

Wants to merge before INFRA acts on INFRA-28233 — `.asf.yaml` stops being applied once the repository is read only.

<sub>Drafted with Claude — please verify</sub>